### PR TITLE
CDRIVER-2989: Java bindings

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -40,6 +40,14 @@ functions:
           ${compile_env|} ./libmongocrypt/.evergreen/compile.sh
           ${test_env|} ./libmongocrypt/.evergreen/test.sh
 
+  "build and test java":
+    - command: "shell.exec"
+      params:
+        script: |-
+          eval "${inject_env_from_evergreen}"
+          ${compile_env|} ./libmongocrypt/.evergreen/compile.sh
+          cd ./libmongocrypt/bindings/java/mongocrypt && ${test_env|} ./.evergreen/test.sh
+
 tasks:
 - name: build-and-test
   commands:
@@ -64,6 +72,11 @@ tasks:
       test_env: VALGRIND="valgrind --leak-check=full --error-exitcode=1"
 
   - func: "tar and upload libmongocrypt libraries"
+
+- name: build-and-test-java
+  commands:
+    - func: "fetch source"
+    - func: "build and test java"
 
 pre:
   # Update the evergreen expansion to dynamically set the ${libmongocrypt_s3_path} expansion.
@@ -92,24 +105,28 @@ buildvariants:
   - build-and-test
   - build-and-test-asan
   - build-and-test-valgrind
+  - build-and-test-java
 - name: rhel76
   display_name: "RHEL 7.6"
   run_on: rhel76-test
   tasks:
   - build-and-test
   - build-and-test-asan
+  - build-and-test-java
 - name: macos
   display_name: "macOS 10.14"
   run_on: macos-1014
   tasks:
   - build-and-test
   - build-and-test-asan
+  - build-and-test-java
 - name: rhel72-zseries-test
   display_name: "RHEL 7.2 on zSeries"
   run_on: rhel72-zseries-test
   tasks:
   - build-and-test
   - build-and-test-asan
+  - build-and-test-java
 - name: windows-test
   display_name: "Windows 2016"
   run_on: windows-64-vs2017-test

--- a/bindings/java/mongocrypt/.evergreen/test.sh
+++ b/bindings/java/mongocrypt/.evergreen/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Test the Java bindings for libmongocrypt
+
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+export JAVA_HOME="/opt/java/jdk8"
+
+if [ "Windows_NT" = "$OS" ]; then
+   export JAVA_HOME=/cygdrive/c/java/jdk8
+else
+   export JAVA_HOME=/opt/java/jdk8
+fi
+
+./gradlew -version
+
+./gradlew -Djna.library.path="../../../cmake-build" clean check

--- a/bindings/java/mongocrypt/src/test/resources/encrypted-command-reply.json
+++ b/bindings/java/mongocrypt/src/test/resources/encrypted-command-reply.json
@@ -4,7 +4,7 @@
       {
         "_id": 1,
         "ssn": {
-          "$binary": "AQAAAAAAAAAAAAAAAAAAAAACaWlpaWlpaWlpaWlpaWlpabxsgJndMBCMERBAi/fCAOAQu6/LKU2mu5X7FLmEJlhkHsRr7TxMoz/2akbqBBzCVn1FXiIe9esJCgNhan6EY8g=",
+          "$binary": "AQAAAAAAAAAAAAAAAAAAAAACaWlpaWlpaWlpaWlpaWlpabfqziGLfQanzdB1yTEzR8Nl4+IuG7Yc6R41O6bzGedZj6JUuaRfevH1qnjIOhQ+99fG4Dzxc62EXjpGa4Yz9n0=",
           "$type": "06"
         }
       }

--- a/bindings/java/mongocrypt/src/test/resources/encrypted-command.json
+++ b/bindings/java/mongocrypt/src/test/resources/encrypted-command.json
@@ -1,7 +1,7 @@
 {
   "filter": {
     "ssn": {
-      "$binary": "AQAAAAAAAAAAAAAAAAAAAAACaWlpaWlpaWlpaWlpaWlpabxsgJndMBCMERBAi/fCAOAQu6/LKU2mu5X7FLmEJlhkHsRr7TxMoz/2akbqBBzCVn1FXiIe9esJCgNhan6EY8g=",
+      "$binary": "AQAAAAAAAAAAAAAAAAAAAAACaWlpaWlpaWlpaWlpaWlpabfqziGLfQanzdB1yTEzR8Nl4+IuG7Yc6R41O6bzGedZj6JUuaRfevH1qnjIOhQ+99fG4Dzxc62EXjpGa4Yz9n0=",
       "$type": "06"
     }
   },

--- a/bindings/java/mongocrypt/src/test/resources/key-filter.json
+++ b/bindings/java/mongocrypt/src/test/resources/key-filter.json
@@ -1,10 +1,19 @@
 {
-  "_id": {
-    "$in": [
-      {
-        "$binary": "AAAAAAAAAAAAAAAAAAAAAA==",
-        "$type": "04"
+  "$or": [
+    {
+      "_id": {
+        "$in": [
+          {
+            "$binary": "AAAAAAAAAAAAAAAAAAAAAA==",
+            "$type": "04"
+          }
+        ]
       }
-    ]
-  }
+    },
+    {
+      "keyAltName": {
+        "$in": []
+      }
+    }
+  ]
 }


### PR DESCRIPTION
- Update Java binding tests to match libmongocrypt
- Add Evergreen testing of Java binding

Windows is not linking properly so I haven't enabled the tests yet for that variant:

Patch build from before I disabled Windows: https://evergreen.mongodb.com/version/5cdb1664e3c3312d98b517e0 