### PR TITLE
update Java bindings for new crypto changes

### DIFF
--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -376,22 +376,6 @@ public class CAPI {
 
 
     /**
-     * Set an initialization vector to be used with explicit
-     * encryption. This should not be set for auto encryption.
-     *
-     * If using randomized encryption, setting this option will
-     * cause an error. If using deterministic encryption, failing
-     * to set this option will cause an error.
-     *
-     * @param ctx The @ref mongocrypt_ctx_t object.
-     * @param iv The initialization vector to use.
-     * @return A boolean indicating success.
-     */
-    public static native boolean
-    mongocrypt_ctx_setopt_initialization_vector (mongocrypt_ctx_t ctx,
-                                                 mongocrypt_binary_t iv);
-
-    /**
      * Create a new uninitialized @ref mongocrypt_ctx_t.
      * <p>
      * Initialize the context with functions like @ref mongocrypt_ctx_encrypt_init.

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
@@ -40,7 +40,6 @@ import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_encrypt_init;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_explicit_encrypt_init;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_new;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_algorithm;
-import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_initialization_vector;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_key_id;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_masterkey_aws;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_masterkey_local;
@@ -204,18 +203,6 @@ class MongoCryptImpl implements MongoCrypt {
         success = mongocrypt_ctx_setopt_algorithm(context, new cstring(options.getAlgorithm()), -1);
         if (!success) {
             MongoCryptContextImpl.throwExceptionFromStatus(context);
-        }
-
-        if (options.getInitializationVector() != null) {
-            mongocrypt_binary_t initializationVectorBinary = toBinary(ByteBuffer.wrap(options.getInitializationVector()));
-            try {
-                success = mongocrypt_ctx_setopt_initialization_vector(context, initializationVectorBinary);
-                if (!success) {
-                    MongoCryptContextImpl.throwExceptionFromStatus(context);
-                }
-            } finally {
-                mongocrypt_binary_destroy(initializationVectorBinary);
-            }
         }
 
         mongocrypt_binary_t documentBinary = toBinary(document);

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoExplicitEncryptOptions.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoExplicitEncryptOptions.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 public class MongoExplicitEncryptOptions {
     private final BsonBinary keyId;
     private final String algorithm;
-    private final byte[] initializationVector;
 
     /**
      * The builder for the options
@@ -35,7 +34,6 @@ public class MongoExplicitEncryptOptions {
     public static class Builder {
         private BsonBinary keyId;
         private String algorithm;
-        private byte[] initializationVector;
 
         private Builder() {
         }
@@ -59,16 +57,6 @@ public class MongoExplicitEncryptOptions {
          */
         public Builder algorithm(final String algorithm) {
             this.algorithm = algorithm;
-            return this;
-        }
-
-        /**
-         * Add the initialization vector
-         * @param initializationVector the initialization vector
-         * @return this
-         */
-        public Builder initializationVector(final byte[] initializationVector) {
-            this.initializationVector = initializationVector;
             return this;
         }
 
@@ -107,26 +95,15 @@ public class MongoExplicitEncryptOptions {
         return algorithm;
     }
 
-    /**
-     * Gets the initialization vector
-     * @return the initialization vector
-     */
-    public byte[] getInitializationVector() {
-        return initializationVector;
-    }
-
     private MongoExplicitEncryptOptions(Builder builder) {
         this.keyId = builder.keyId;
         this.algorithm = builder.algorithm;
-        this.initializationVector = builder.initializationVector;
     }
 
     @Override
     public String toString() {
         return "MongoExplicitEncryptOptions{" +
                 "keyId=" + keyId +
-                ", algorithm='" + algorithm + '\'' +
-                ", initializationVector=" + Arrays.toString(initializationVector) +
-                '}';
+                ", algorithm='" + algorithm + "'}";
     }
 }

--- a/bindings/java/mongocrypt/src/test/java/com/mongodb/crypt/capi/MongoCryptTest.java
+++ b/bindings/java/mongocrypt/src/test/java/com/mongodb/crypt/capi/MongoCryptTest.java
@@ -127,9 +127,8 @@ public class MongoCryptTest {
 
         BsonDocument documentToEncrypt = new BsonDocument("v", new BsonString("hello"));
         MongoExplicitEncryptOptions options = MongoExplicitEncryptOptions.builder()
-                .keyId(new BsonBinary(BsonBinarySubType.UUID_STANDARD, Base64.getDecoder().decode("AAAAAAAAAAAAAAAAAAAAAA==")))
+                .keyId(new BsonBinary(BsonBinarySubType.UUID_STANDARD, Base64.getDecoder().decode("YWFhYWFhYWFhYWFhYWFhYQ==")))
                 .algorithm("AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic")
-                .initializationVector(Base64.getDecoder().decode("aWlpaWlpaWlpaWlpaWlpaQ=="))
                 .build();
         MongoCryptContext encryptor = mongoCrypt.createExplicitEncryptionContext(documentToEncrypt, options);
         assertEquals(State.NEED_MONGO_KEYS, encryptor.getState());
@@ -166,7 +165,7 @@ public class MongoCryptTest {
         assertEquals("kms.us-east-1.amazonaws.com", keyDecryptor.getHostName());
 
         ByteBuffer keyDecryptorMessage = keyDecryptor.getMessage();
-        assertEquals(741, keyDecryptorMessage.remaining());
+        assertEquals(781, keyDecryptorMessage.remaining());
 
         int bytesNeeded = keyDecryptor.bytesNeeded();
         assertEquals(1024, bytesNeeded);
@@ -188,7 +187,7 @@ public class MongoCryptTest {
                         .secretAccessKey("example")
                         .build())
                 .localKmsProviderOptions(MongoLocalKmsProviderOptions.builder()
-                        .localMasterKey(ByteBuffer.wrap(new byte[64]))
+                        .localMasterKey(ByteBuffer.wrap(new byte[96]))
                         .build())
                 .build());
     }

--- a/bindings/java/mongocrypt/src/test/resources/collection-info.json
+++ b/bindings/java/mongocrypt/src/test/resources/collection-info.json
@@ -21,18 +21,12 @@
                         "encrypt": {
                             "keyId": {
                                 "$binary": {
-                                    "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                                    "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
                                     "subType": "04"
                                 }
                             },
                             "type": "string",
-                            "algorithm": "Deterministic",
-                            "iv": {
-                                "$binary": {
-                                    "base64": "aWlpaWlpaWlpaWlpaWlpaQ==",
-                                    "subType": "00"
-                                }
-                            }
+                            "algorithm": "AEAD_AES_CBC_HMAC_SHA512-Deterministic"
                         }
                     }
                 },

--- a/bindings/java/mongocrypt/src/test/resources/encrypted-command-reply.json
+++ b/bindings/java/mongocrypt/src/test/resources/encrypted-command-reply.json
@@ -4,7 +4,7 @@
       {
         "_id": 1,
         "ssn": {
-          "$binary": "AQAAAAAAAAAAAAAAAAAAAAACaWlpaWlpaWlpaWlpaWlpabfqziGLfQanzdB1yTEzR8Nl4+IuG7Yc6R41O6bzGedZj6JUuaRfevH1qnjIOhQ+99fG4Dzxc62EXjpGa4Yz9n0=",
+          "$binary": "AWFhYWFhYWFhYWFhYWFhYWEC6f/1CgA+ncYs+mYa7q5ftmJVcJloVf+m8YBRGxZWo3qQkFSerlbOh71KRvffB7NH061iG8ctrYFv2BDRw+VQYEyJ1GrvJGaYr1Cuu7CW2KY=",
           "$type": "06"
         }
       }

--- a/bindings/java/mongocrypt/src/test/resources/encrypted-command.json
+++ b/bindings/java/mongocrypt/src/test/resources/encrypted-command.json
@@ -1,7 +1,7 @@
 {
   "filter": {
     "ssn": {
-      "$binary": "AQAAAAAAAAAAAAAAAAAAAAACaWlpaWlpaWlpaWlpaWlpabfqziGLfQanzdB1yTEzR8Nl4+IuG7Yc6R41O6bzGedZj6JUuaRfevH1qnjIOhQ+99fG4Dzxc62EXjpGa4Yz9n0=",
+      "$binary": "AWFhYWFhYWFhYWFhYWFhYWEC6f/1CgA+ncYs+mYa7q5ftmJVcJloVf+m8YBRGxZWo3qQkFSerlbOh71KRvffB7NH061iG8ctrYFv2BDRw+VQYEyJ1GrvJGaYr1Cuu7CW2KY=",
       "$type": "06"
     }
   },

--- a/bindings/java/mongocrypt/src/test/resources/encrypted-value.json
+++ b/bindings/java/mongocrypt/src/test/resources/encrypted-value.json
@@ -1,6 +1,6 @@
 {
   "v": {
-    "$binary": "AQAAAAAAAAAAAAAAAAAAAAACaWlpaWlpaWlpaWlpaWlpaQbQ32g4BA9akovftkP9hG80AtjRF1Hp4+U6sathb1BqdBNzbLz9M7ZOJh+FehqdLA==",
+    "$binary": "AWFhYWFhYWFhYWFhYWFhYWECgbOimGisUlRv6/pLLj2iczH46GWWGMVovweA8XrtYs11wDfgLRW6qezGMs6i3jLlp/ZCNOH95PZPazoe6GiZgg==",
     "$type": "06"
   }
 }

--- a/bindings/java/mongocrypt/src/test/resources/json-schema.json
+++ b/bindings/java/mongocrypt/src/test/resources/json-schema.json
@@ -3,15 +3,11 @@
     "ssn": {
       "encrypt": {
         "keyId": {
-          "$binary": "AAAAAAAAAAAAAAAAAAAAAA==",
+          "$binary": "YWFhYWFhYWFhYWFhYWFhYQ==",
           "$type": "04"
         },
         "type": "string",
-        "algorithm": "Deterministic",
-        "iv": {
-          "$binary": "aWlpaWlpaWlpaWlpaWlpaQ==",
-          "$type": "00"
-        }
+        "algorithm": "AEAD_AES_CBC_HMAC_SHA512-Deterministic"
       }
     }
   },

--- a/bindings/java/mongocrypt/src/test/resources/key-document.json
+++ b/bindings/java/mongocrypt/src/test/resources/key-document.json
@@ -4,29 +4,29 @@
     },
     "_id": {
         "$binary": {
-            "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+            "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
             "subType": "04"
         }
     },
     "masterKey": {
-        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
         "region": "us-east-1",
+        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
         "provider": "aws"
     },
-    "updatedDate": {
+    "updateDate": {
         "$date": {
-            "$numberLong": "1553026537755"
+            "$numberLong": "1557827033449"
         }
     },
     "keyMaterial": {
         "$binary": {
-            "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEdnNDpvEH3aukK7+DVjuYXAAAAojCBnwYJKoZIhvcNAQcGoIGRMIGOAgEAMIGIBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDIkm/uaBLakm8bozbQIBEIBbvPB7EluCCXGmVRrV7r/wK3lqgb1do4fwRL0Yw2Mbdb+ignWGtWYNssDLT8N+zNm8gUYdoazLu8X5zsUJJdyPhRru85SR0Iw2lt9WdXrH3E0KAkpUeRt4oaQX2w==",
+            "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gF9FSYZL9Ze8TvTA3WBd3nmAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDLV3GHktEO8AlpsYBwIBEIB7ho0DQF7hEQPRz/8b61AHm2czX53Y9BNu5z+oyGYsoP643M58aTGsaHQzkTaAmGKlZTAEOjJkRJ4gZoabVuv4g6aJqf4k4w8pK7iIgHwMNy4nbUAqOWmqtnKpHZgy6jcFN2DzZzHIi4SNFsCkFc6Aw30ixtvqIDQPAXMW",
             "subType": "00"
         }
     },
     "creationDate": {
         "$date": {
-            "$numberLong": "1553026537755"
+            "$numberLong": "1557827033449"
         }
     }
 }

--- a/bindings/java/mongocrypt/src/test/resources/key-filter.json
+++ b/bindings/java/mongocrypt/src/test/resources/key-filter.json
@@ -4,7 +4,7 @@
       "_id": {
         "$in": [
           {
-            "$binary": "AAAAAAAAAAAAAAAAAAAAAA==",
+            "$binary": "YWFhYWFhYWFhYWFhYWFhYQ==",
             "$type": "04"
           }
         ]

--- a/bindings/java/mongocrypt/src/test/resources/kms-reply.txt
+++ b/bindings/java/mongocrypt/src/test/resources/kms-reply.txt
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 x-amzn-RequestId: deeb35e5-4ecb-4bf1-9af5-84a54ff0af0e
 Content-Type: application/x-amz-json-1.1
-Content-Length: 193
+Content-Length: 233
 
-{"Plaintext": "Y2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYw==", "KeyId": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"}
+{"Plaintext": "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh", "KeyId": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"}

--- a/bindings/java/mongocrypt/src/test/resources/mongocryptd-reply.json
+++ b/bindings/java/mongocrypt/src/test/resources/mongocryptd-reply.json
@@ -7,7 +7,7 @@
         "filter": {
             "ssn": {
                 "$binary": {
-                    "base64": "AFEAAAAQYQABAAAABWtpABAAAAAEAAAAAAAAAAAAAAAAAAAAAAVpdgAQAAAAAGlpaWlpaWlpaWlpaWlpaWkCdgAMAAAANDU3LTU1LTU0NjIAAA==",
+                    "base64": "ADgAAAAQYQABAAAABWtpABAAAAAEYWFhYWFhYWFhYWFhYWFhYQJ2AAwAAAA0NTctNTUtNTQ2MgAA",
                     "subType": "06"
                 }
             }


### PR DESCRIPTION
Remove IV per API changes, and update the test data for the new larger 96 byte key.

Fixes the build-and-test-java task in Evergreen:
https://evergreen.mongodb.com/version/5ce61a7157e85a2ac530ab4c